### PR TITLE
Fixed install "platform-tools" issue.

### DIFF
--- a/dumpyara/dumpyara.py
+++ b/dumpyara/dumpyara.py
@@ -30,7 +30,7 @@ def dumpyara(file: Path, output_path: Path, debug: bool = False):
 	# First, check the necessary tools are installed
 	for tool, package in REQUIRED_TOOLS.items():
 		if not which(tool):
-			raise RuntimeError(f"Please install {package} required by {tool} from your distro's repositories")
+			raise RuntimeError(f"Please install {package} for {tool} from your distro's repositories")
 
 	try:
 		# Make output and temporary directories

--- a/dumpyara/dumpyara.py
+++ b/dumpyara/dumpyara.py
@@ -17,7 +17,7 @@ from dumpyara.steps.prepare_images import prepare_images
 REQUIRED_TOOLS = {
 	"7z": "p7zip",
 	"fsck.erofs": "erofs-utils",
-	"simg2img": "platform-tools",
+	"simg2img": "android-sdk-libsparse-utils", 
 }
 
 def dumpyara(file: Path, output_path: Path, debug: bool = False):
@@ -30,7 +30,7 @@ def dumpyara(file: Path, output_path: Path, debug: bool = False):
 	# First, check the necessary tools are installed
 	for tool, package in REQUIRED_TOOLS.items():
 		if not which(tool):
-			raise RuntimeError(f"Please install {package} from your distro's repositories")
+			raise RuntimeError(f"Please install {package} required by {tool} from your distro's repositories")
 
 	try:
 		# Make output and temporary directories


### PR DESCRIPTION
Well it was not an issue. Only problem was "simg2img" is part of "android-sdk-libsparse-utils". So, instead of displaying install platform tools, install "android-sdk-libsparse-utils" works. Also analyzing script's REQUIRED_TOOLS() worked for me so I did add the display tool.