### PR TITLE
dumpyara: utils: multipartitions: Do not match .lz4 files

### DIFF
--- a/dumpyara/utils/multipartitions.py
+++ b/dumpyara/utils/multipartitions.py
@@ -36,6 +36,6 @@ MULTIPARTITIONS: Dict[Pattern[str], Callable[[Path, Path], None]] = {
 	compile(key): value
 	for key, value in {
 		"payload.bin": extract_payload,
-		"super(?!.*(_empty)).*\\.img": extract_super,
+		"super(?!.*(_empty)).*\\.img(?!(\\.lz4))": extract_super,
 	}.items()
 }


### PR DESCRIPTION
Fixes: https://github.com/sebaubuntu-python/dumpyara/issues/83