### PR TITLE
dumpyara: resolve relative path when using custom output directory

### DIFF
--- a/dumpyara/main.py
+++ b/dumpyara/main.py
@@ -33,7 +33,7 @@ def main():
 
     output = Path.cwd() / args.file.stem
     if args.output:
-        output = args.output
+        output = args.output.resolve()
 
     output_path = dumpyara(args.file, output, args.debug)
 


### PR DESCRIPTION
The relative path causes issues with AIK in the nixpkgs package for dumpyara.